### PR TITLE
Fixed rectangle/filledRectangle calls

### DIFF
--- a/lib/Graphics/Primitive/Driver/GD.pm
+++ b/lib/Graphics/Primitive/Driver/GD.pm
@@ -450,12 +450,14 @@ sub _draw_rectangle {
     if($self->fill_mode) {
         $gd->filledRectangle(
             $comp->origin->x, $comp->origin->y,
-            $comp->origin->x + $comp->width, $comp->origin->y + $comp->height
+            $comp->origin->x + $comp->width, $comp->origin->y + $comp->height,
+            gdStyled
         );
     } else {
         $gd->rectangle(
             $comp->origin->x, $comp->origin->y,
-            $comp->origin->x + $comp->width, $comp->origin->y + $comp->height
+            $comp->origin->x + $comp->width, $comp->origin->y + $comp->height,
+            gdStyled
         );
     }
 }


### PR DESCRIPTION
The GD’s `rectangle` & `filledRectangle` functions calls requires 5 arguments, not 4.
